### PR TITLE
Add beatbot script to celebrate GPT-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # test-codex
+
+This repository now includes a simple script that uses the `beatbot` library to make a celebratory beat for GPT-5.
+
+## Usage
+
+```bash
+pip install beatbot
+python beat_gpt5.py
+```
+
+Running the script will create `gpt5_celebration.wav` in the current directory.

--- a/beat_gpt5.py
+++ b/beat_gpt5.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Generate a celebratory beat for GPT-5 using beatbot."""
+
+from beatbot import Beat, Kick, Snare, HiHat
+
+
+def make_gpt5_beat(output_file: str = "gpt5_celebration.wav") -> None:
+    """Create and export a celebratory beat for GPT-5."""
+    bpm = 120
+    beat = Beat(bpm=bpm, bars=4)
+    beat.add_track(Kick(pattern="x---x---x---x---"))
+    beat.add_track(Snare(pattern="----x-------x---"))
+    beat.add_track(HiHat(pattern="x-x-x-x-x-x-x-x-"))
+    beat.render(output_file)
+
+
+if __name__ == "__main__":
+    make_gpt5_beat()


### PR DESCRIPTION
## Summary
- add a beatbot-based script that generates a celebratory beat for GPT-5
- document beatbot usage in README

## Testing
- `python -m py_compile beat_gpt5.py`
- `pytest`
- `python beat_gpt5.py` *(fails: No module named 'beatbot')*


------
https://chatgpt.com/codex/tasks/task_e_68956d0a8c7c833397e58435c2aa7ca7